### PR TITLE
Fix LVV-T1802 to run from start to finish on TTS.

### DIFF
--- a/notebooks/proj_sys_eng/sitcom_integration/LVV-T1802-Integ_m2hex_sal.ipynb
+++ b/notebooks/proj_sys_eng/sitcom_integration/LVV-T1802-Integ_m2hex_sal.ipynb
@@ -283,7 +283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "await salobj.set_summary_state(hexapod_csc, salobj.State.STANDBY)"
+    "await salobj.set_summary_state(hexapod_csc, salobj.State.DISABLED)"
    ]
   },
   {
@@ -511,6 +511,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hexapod_csc.evt_interlock.get().get_vars"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -524,7 +533,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "e = vandv.check_last_evt(hexapod_csc.evt_interlock.get())"
+    "e = vandv.check_last_evt(hexapod_csc.evt_interlock)"
    ]
   },
   {
@@ -698,7 +707,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "e = vandv.check_last_evt(hexapod_csc.tel_electrical.get())"
+    "e = vandv.check_last_evt(hexapod_csc.tel_electrical)"
    ]
   },
   {
@@ -1011,7 +1020,9 @@
    "metadata": {},
    "source": [
     "The `setCompensationMode` expects information from the MTmount(elevation) and MTRotator(rotation).\n",
-    "So we need to check if both are in the ENABLED state (or at least in DISABLED state) and that they are publishing the required data."
+    "So we need to check if both are in the ENABLED state (or at least in DISABLED state) and that they are publishing the required data.  \n",
+    "\n",
+    "In CompenstationMode a LUT is used to compensate during the movements."
    ]
   },
   {
@@ -1021,16 +1032,16 @@
    "outputs": [],
    "source": [
     "e = mount.evt_summaryState.get()\n",
-    "logging.info(e.private_identity, MTHexapod.ControllerState(e.summaryState))\n",
+    "logging.info(f'{e.private_identity} is: {salobj.State(e.summaryState).name}')\n",
     "\n",
     "t = mount.tel_elevation.get()\n",
-    "logging.info(t.private_identity, t.actualPosition)\n",
+    "logging.info(f'{t.private_identity} at: {t.actualPosition:2.2f}')\n",
     "\n",
     "e = rotator.evt_summaryState.get()\n",
-    "logging.info(e.private_identity, MTHexapod.ControllerState(e.summaryState))\n",
+    "logging.info(f'{e.private_identity} is: {salobj.State(e.summaryState).name}')\n",
     "\n",
     "t = rotator.tel_rotation.get()\n",
-    "logging.info(t.private_identity, t.actualPosition)"
+    "logging.info(f'{t.private_identity} at: {t.actualPosition:2.2f}')"
    ]
   },
   {
@@ -1386,24 +1397,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Start test\n",
     "script.log.info(f\"START - {test_message} -- {test_case} {test_exec} Test configureLimits\")\n",
     "\n",
     "# Try to set a new configuration - It should fail \n",
-    "hexapod_csc.cmd_configureLimits.set_start(maxXY=12000, minZ=-1000, maxZ=1000, maxUV=0.1, minW=-0.1, maxW=0.05)"
+    "await hexapod_csc.cmd_configureLimits.set_start(maxXY=11000, minZ=-1000, maxZ=1000, maxUV=0.1, minW=-0.1, maxW=0.05)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Try again with reasonable values\n",
-    "hexapod_csc.cmd_configureLimits.set_start(maxXY=1000, minZ=-1000, maxZ=1000, maxUV=0.1, minW=-0.1, maxW=0.05)"
+    "await hexapod_csc.cmd_configureLimits.set_start(maxXY=1000, minZ=-1000, maxZ=1000, maxUV=0.1, minW=-0.05, maxW=0.05)"
    ]
   },
   {
@@ -1435,10 +1450,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
-    "# Move the hexapod again, the command should be rejected\n",
+    "# Move the hexapod again, the command should be accepted\n",
     "await hexapod_csc.cmd_move.set_start(x=990, y=990, z=200, u=0, v=0, w=0, sync=True)"
    ]
   },
@@ -1448,7 +1465,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Move the hexapod again, the command should be rejected\n",
+    "# Move the hexapod again, the command should be accepted\n",
     "await hexapod_csc.cmd_move.set_start(x=500, y=500, z=200, u=0, v=0.1, w=0.01, sync=True)\n",
     "\n",
     "# Wait movement to complete\n",
@@ -1499,6 +1516,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# For the following tests, first reset the limits to the EUI defaults of accomodate them.\n",
+    "await hexapod_csc.cmd_configureLimits.set_start(maxXY=10500, minZ=-8900, maxZ=8900, maxUV=0.1750, minW=-0.05, maxW=0.05)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Start test\n",
     "script.log.info(f\"START - {test_message} -- {test_case} {test_exec} Test configureAcceleration\")"
    ]
@@ -1524,7 +1551,7 @@
    "outputs": [],
    "source": [
     "# Update the acceleration, the command should be rejected\n",
-    "await hexapod_csc.cmd_configureAcceleration.set_start(1000)"
+    "await hexapod_csc.cmd_configureAcceleration.set_start(acceleration=1000)"
    ]
   },
   {
@@ -1534,7 +1561,7 @@
    "outputs": [],
    "source": [
     "# Update the acceleration, the command should be accepted\n",
-    "await hexapod_csc.cmd_configureAcceleration.set_start(100)"
+    "await hexapod_csc.cmd_configureAcceleration.set_start(acceleration=100)"
    ]
   },
   {
@@ -1558,7 +1585,7 @@
    "outputs": [],
    "source": [
     "# Update the acceleration to the nominal value\n",
-    "await hexapod_csc.cmd_configureAcceleration.set_start(500)"
+    "await hexapod_csc.cmd_configureAcceleration.set_start(acceleration=500)"
    ]
   },
   {
@@ -1597,7 +1624,7 @@
    "outputs": [],
    "source": [
     "# Change velocity\n",
-    "await hexapod_csc.cmd_configureVelocity.set_start(xy=100, z=0.01, uv=200, w=0.01)"
+    "await hexapod_csc.cmd_configureVelocity.set_start(xy=100, z=200.0, uv=0.01, w=0.01)"
    ]
   },
   {
@@ -1608,6 +1635,7 @@
    "source": [
     "# todo @bquint - add a callback to track how much time it takes to complete\n",
     "# Move the hexapod, it should take ~20s to complete\n",
+    "\n",
     "await hexapod_csc.cmd_move.set_start(x=0, y=0, z=2000, u=0, v=0, w=0, sync=True)\n",
     "\n",
     "# Wait movement to complete\n",
@@ -1621,7 +1649,7 @@
    "outputs": [],
    "source": [
     "# Change velocity\n",
-    "await hexapod_csc.cmd_configureVelocity.set_start(xy=100, z=0.01, uv=100, w=0.01)"
+    "await hexapod_csc.cmd_configureVelocity.set_start(xy=100, z=100, uv=0.01, w=0.01)"
    ]
   },
   {
@@ -1660,84 +1688,82 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Endurance test for the M2 hexapod. CAVE: This are very long moves. This can overheat the hexapod see.\n",
-    "#LVV-T1600 for shorter moves\n",
+    "# Hexapod envelope Test\n",
     "\n",
-    "script.log.info(f\"START- {test_message} -- LVV-T1802 Endurance Test\")\n",
-    "for i in range(100):\n",
-    "    await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=5900,u=0,v=0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=5900,u=0,v=-0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=5900,u=0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=5900,u=-0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
+    "script.log.info(f\"START- {test_message} -- LVV-T1802 Envelope Test\")\n",
     "\n",
-    "    await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=-5900,u=0,v=0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=-5900,u=0,v=-0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=-5900,u=0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=-5900,u=-0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=5900,u=0,v=0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=5900,u=0,v=-0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=5900,u=0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=5900,u=-0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
     "\n",
-    "    await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=5900,u=0,v=0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=5900,u=0,v=-0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=5900,u=0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=5900,u=-0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=-5900,u=0,v=0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=-5900,u=0,v=-0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=-5900,u=0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=6700,y=0,z=-5900,u=-0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
     "\n",
-    "    await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=-5900,u=0,v=0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=-5900,u=0,v=-0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=-5900,u=0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=-5900,u=-0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=5900,u=0,v=0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=5900,u=0,v=-0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=5900,u=0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=5900,u=-0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "\n",
+    "await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=-5900,u=0,v=0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=-5900,u=0,v=-0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=-5900,u=0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=-6700,y=0,z=-5900,u=-0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
     "\n",
     "\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=5900,u=0,v=0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=5900,u=0,v=-0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=5900,u=0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=5900,u=-0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=5900,u=0,v=0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=5900,u=0,v=-0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=5900,u=0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=5900,u=-0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
     "\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=-5900,u=0,v=0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=-5900,u=0,v=-0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=-5900,u=0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=-5900,u=-0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=-5900,u=0,v=0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=-5900,u=0,v=-0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=-5900,u=0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=6700,z=-5900,u=-0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
     "\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=5900,u=0,v=0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=5900,u=0,v=-0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=5900,u=0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=5900,u=-0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=5900,u=0,v=0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=5900,u=0,v=-0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=5900,u=0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=5900,u=-0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
     "\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=-5900,u=0,v=0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=-5900,u=0,v=-0.12,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=-5900,u=0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "    await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=-5900,u=-0.12,v=0,w=0,sync=True)\n",
-    "    await asyncio.sleep(STD_WAIT)\n",
-    "\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=-5900,u=0,v=0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=-5900,u=0,v=-0.12,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=-5900,u=0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
+    "await hexapod_csc.cmd_move.set_start(x=0,y=-6700,z=-5900,u=-0.12,v=0,w=0,sync=True)\n",
+    "await asyncio.sleep(STD_WAIT)\n",
     "\n",
     "script.log.info(f\"STOPP- {test_message} -- LVV-T1802 Endurance Test \")"
    ]
@@ -1759,6 +1785,13 @@
    "source": [
     "await domain.close() # Close the remote connection"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
- Fix typos to make the notebook run
    - remove extra .get() s etc
    - fix incorrect assignment between variable names in velocity commands
    - Fix some incorrect ‘accepted’ vs ‘rejected’ text.

- I added an explanatory sentence:’In CompenstationMode a LUT is used to
compensate during the movements.’

- Correct the procedure to read and printout the summary state
variables.

- Fix the cmd_configureLimits cells that were missing ‘await’ commands,
Now the command is really issued.

- Before the acceleration and velocity commands, add a new cell to reset
the configuration limits to their defaults as seen on the EUI.

- Fix the hexapod_csc.cmd_configureAcceleration.set_start to use an
‘acceleration’ keyword.

- Remove the final stress test loop and rename it to be Hexapod Envelope
test

Note: There are still notes from Bruno in the notebook about new
things that need to be implemented.

Note: There is some confusing text from Holger that came from the Jira
test case:

‘The following steps define what the Jupyter Notebook for this test
case implements. Executing the Jupyter notebook is the only actual
command and control step that needs to be executed. Transition the
state machine into disabledState to publish telemetry.’

To check for the future: The association between calibrated and raw
etc strut positions do not seem to agree well with the printed out
hexapod positions.