### PR TITLE
Make the fixed-dome-notebook work with 2024 configurations.

### DIFF
--- a/notebooks/tel_and_site/subsys_req_ver/tma/fixed-dome-startracker.ipynb
+++ b/notebooks/tel_and_site/subsys_req_ver/tma/fixed-dome-startracker.ipynb
@@ -42,10 +42,10 @@
     "test_case = \"LVV-TXXX\"\n",
     "test_exec = \"LVV-EXXXX\" \n",
     "\n",
-    "camera_sal_indexes = [101, 102]\n",
+    "camera_sal_indexes = [101, 102, 103]\n",
     "#camera_sal_indexes = [102]\n",
     "\n",
-    "exposure_times = [10., 5.]  # s\n",
+    "exposure_times = [10., 5., 1.]  # s\n",
     "base_msg = f\"{test_case} {test_exec}:\""
    ]
   },
@@ -165,6 +165,7 @@
     "\n",
     "    gencam = GenericCamera(domain=domain, index=index, log=log)\n",
     "    await gencam.start_task\n",
+    "    await gencam.enable()\n",
     "\n",
     "    camera_list.append(gencam)\n"
    ]
@@ -278,8 +279,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "num_exposures = [1, 1]\n",
-    "exposure_times = [5.0, 2.0]\n",
+    "num_exposures = [5, 5, 5]\n",
+    "exposure_times = [5.0, 2.0, 1.0]\n",
     "reason = \"Test exposures with fixed TMA\"\n",
     "\n",
     "\n",
@@ -336,7 +337,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
These changes:

- Add the third fast camera to the list of readout devices.
- Adds a now required command to enable the cameras.