### PR TITLE
Add example notebook for retrieving block information.

### DIFF
--- a/notebooks/SITCOM-1209_blocks_in_time_range.ipynb
+++ b/notebooks/SITCOM-1209_blocks_in_time_range.ipynb
@@ -94,6 +94,59 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Produce a Pandas data frame with block information.  More information can be\n",
+    "# added as needed by modifying the function and following the pattern\n",
+    "# in the code.\n",
+    "\n",
+    "def day_obs_dataframe(day_obs):\n",
+    "    '''\n",
+    "    Loop over the blocks and sequences for one day and produce a pandas dataframe.\n",
+    "    containing the BLOCK number, BLOCK ID, time start, time stop, and reason for stopping.\n",
+    "    \n",
+    "    This function returns a pandas dataframe\n",
+    "    '''\n",
+    "\n",
+    "    entry_list = []\n",
+    "\n",
+    "    block_parser = BlockParser(day_obs)\n",
+    "    blocks = block_parser.getBlockNums()\n",
+    "\n",
+    "    for block_id in blocks:\n",
+    "        sequences =  block_parser.getSeqNums(block_id)\n",
+    "\n",
+    "        for seq_id in sequences:\n",
+    "            info = block_parser.getBlockInfo(block_id, seq_id)\n",
+    "\n",
+    "            start_time = info.begin\n",
+    "            end_time = info.end\n",
+    "            reason = info.states[-1]\n",
+    "\n",
+    "            entry_list.append([block_id, seq_id, start_time.iso, end_time.iso, \n",
+    "                               reason])\n",
+    "\n",
+    "    data_frame = pd.DataFrame(entry_list, columns = ['Block', 'Sequence', \n",
+    "                                                     'Start', 'Stop', \n",
+    "                                                     'Completion Status'])\n",
+    "    return data_frame\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show example data frame\n",
+    "\n",
+    "day_obs_dataframe(20240205)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "def day_obs_report(day_obs):\n",
     "    '''\n",
     "    Loop over the blocks and sequences for one day and produce a report.\n",
@@ -133,7 +186,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2024-02-27T15:25:56.760764Z",
+     "iopub.status.busy": "2024-02-27T15:25:56.760243Z",
+     "iopub.status.idle": "2024-02-27T15:25:56.763645Z",
+     "shell.execute_reply": "2024-02-27T15:25:56.763293Z",
+     "shell.execute_reply.started": "2024-02-27T15:25:56.760747Z"
+    }
+   },
    "outputs": [],
    "source": [
     "%%html\n",
@@ -159,18 +220,6 @@
    "display_name": "LSST",
    "language": "python",
    "name": "lsst"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.11.7"
   }
  },
  "nbformat": 4,

--- a/notebooks/SITCOM-1209_blocks_in_time_range.ipynb
+++ b/notebooks/SITCOM-1209_blocks_in_time_range.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%config InlineBackend.figure_format = 'retina'\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "import awkward as ak\n",
+    "import awkward_pandas as akpd\n",
+    "\n",
+    "from astropy.time import Time\n",
+    "\n",
+    "from lsst.summit.utils.blockUtils import BlockParser\n",
+    "from lsst.summit.utils.tmaUtils import TMAEventMaker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the blockUtils functions to get info on what blocks were used.\n",
+    "'''\n",
+    "For  \n",
+    "\n",
+    "block_parser = BlockParser(day_obs)  \n",
+    "\n",
+    "you can use:\n",
+    "\n",
+    "block_parser.getBlockNums()  \n",
+    "block_parser.getSeqNums(227)  \n",
+    "block_parser.getRows(227,1)  \n",
+    "\n",
+    "block_parser.printBlockEvolution(227)  \n",
+    "block_parser.getBlockInfo(227,6)  \n",
+    "block_parser.getEventsForBlock(events, 219,1)\n",
+    "'''\n",
+    "\n",
+    "# Set the day_obs list \n",
+    "day_obs_list = range(20240205, 20240205 + 11)\n",
+    "\n",
+    "# For the TMA events \n",
+    "event_maker = TMAEventMaker()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For each day_obs in the list determine which blocks were run and put\n",
+    "# the list of blocks into the block_list.\n",
+    " \n",
+    "block_list = []\n",
+    "\n",
+    "for day_obs in day_obs_list:\n",
+    "    block_parser = BlockParser(day_obs)\n",
+    "    blocks = block_parser.getBlockNums()\n",
+    "    block_list.append(blocks)\n",
+    "\n",
+    "# Put the variable length nested list into an awkward array and then \n",
+    "# put that into a pandas dataframe with the awkward array extension\n",
+    "# so that the list of blocks is shown in a column.\n",
+    "blocks = ak.Array({\"day_obs\": day_obs_list, \"blocks\": block_list})\n",
+    "series = akpd.from_awkward(blocks)\n",
+    "pandas_df = series.ak.to_columns(extract_all=True)\n",
+    "pandas_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example of grabbing manual information on one block/sequence\n",
+    "\n",
+    "block_parser = BlockParser(20240205)\n",
+    "print(\"Sequences Run:\", block_parser.getSeqNums(219))\n",
+    "block_parser.getBlockInfo(219,1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def day_obs_report(day_obs):\n",
+    "    '''\n",
+    "    Loop over the blocks and sequences for one day and produce a report.\n",
+    "    Interspace TMA events with the block info.\n",
+    "    '''\n",
+    "\n",
+    "    block_parser = BlockParser(day_obs)\n",
+    "    tma_events = event_maker.getEvents(day_obs)\n",
+    "    blocks = block_parser.getBlockNums()\n",
+    "\n",
+    "    print(f'SUMMARY REPORT FOR DAYOBS: {day_obs} \\n')\n",
+    "\n",
+    "    for block_id in blocks:\n",
+    "        sequences =  block_parser.getSeqNums(block_id)\n",
+    "\n",
+    "        print(f'BLOCK:SEQ \\t STATES')\n",
+    "\n",
+    "        for seq_id in sequences:\n",
+    "            info = block_parser.getBlockInfo(block_id, seq_id)\n",
+    "            state_string = ' '.join([str(state) for state in info.states])\n",
+    "            print(f'{info.blockNumber}:{info.seqNum} \\t\\t {state_string}')\n",
+    "\n",
+    "            # Also print any TMA events for this block/sequence\n",
+    "            event = block_parser.getEventsForBlock(tma_events, block_id, seq_id)\n",
+    "            if event: print(event)\n",
+    "\n",
+    "        print(f'\\n')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This HTML magick below will make it so the example report below doesn't line wrap. Each line can be quite long."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%html\n",
+    "<style>\n",
+    "div.jp-OutputArea-output pre {\n",
+    "    white-space: pre;\n",
+    "}\n",
+    "</style>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "day_obs_report(20240205)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This notebook is for SITCOM-1209.  It is an example of how you can use the tma summit utils to retrieve information on what blocks were run on a certain range of dayObs.  It also produces a more complete example report. It makes use of awkward arrays and it's panda interface to show a pandas table with variable length lists of block numbers in a column.