### PR TITLE
Install pre-commit hook to prevent notebooks w/ outputs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.1
+    hooks:
+      - id: nbstripout


### PR DESCRIPTION
Just as the title says. 🙂 